### PR TITLE
PLAT-251 allow for additional headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,27 @@ services:
       API_PATH: <service config endpoint>
       MIME_TYPE: <mime type>
       CONFIG_FILE: <config file name>
+      ADDITIONAL_HEADERS: <additional headers in JSON format>
     deploy:
       replicas: 1
       restart_policy:
         condition: none
 ```
 
-HTTP_METHOD       --> The the http verb you wish to use ("POST", "PUT", etc)
-SERVICE_NAME      --> The name of the service as specified in that service's compose file
-SERVICE_API_PORT  --> The port the service listens on from within the docker swarm (not the routed port)
-SSL               --> Set to true for a service running in secure (`https`) mode, and false otherwise
-API_PATH          --> The API endpoint the targeted API uses to import configs
-MIME_TYPE         --> Currently supported options = `multipart/form-data`, `application/json`. Specify this field based on the request body data format
-CONFIG_FILE       --> The name of the config file which forms part of the API request body
+- HTTP_METHOD       --> The the http verb you wish to use ("POST", "PUT", etc)
+- SERVICE_NAME      --> The name of the service as specified in that service's compose file
+- SERVICE_API_PORT  --> The port the service listens on from within the docker swarm (not the routed port)
+- SSL               --> Set to true for a service running in secure (`https`) mode, and false otherwise
+- API_PATH          --> The API endpoint the targeted API uses to import configs
+- MIME_TYPE         --> Currently supported options = `multipart/form-data`, `application/json`. Specify this field based on the request body data format
+- CONFIG_FILE       --> The name of the config file which forms part of the API request body
+- ADDITIONAL_HEADERS --> Includes headers needed to complete the API call. MUST take the form of a json object, i.e., 
+```yml
+  ADDITIONAL_HEADERS: '{
+    "header1": "value1",
+    "header2": "value2"
+  }'
+```
 
 The config importer depends on files placed in the config raft to attach as part of the request body. So, remember to specify your configs in the compose file. 
 

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-npm ci --production && npm clean cache --force
+npm ci --production && npm cache clean --force
 npm run build 
 docker build -t jembi/api-config-importer:latest .
 rm config.js

--- a/configBase.js
+++ b/configBase.js
@@ -14,6 +14,7 @@ const API_USERNAME = process.env.API_USERNAME
 const SSL = process.env.SSL
 const MIME_TYPE = process.env.MIME_TYPE
 const CONFIG_FILE = process.env.CONFIG_FILE
+const ADDITIONAL_HEADERS = process.env.ADDITIONAL_HEADERS ?? ''
 
 let data
 let dataHeaders = {}
@@ -21,8 +22,10 @@ let dataHeaders = {}
 switch (MIME_TYPE) {
   case 'multipart/form-data':
     data = new FormData()
-    data.append('form', fs.createReadStream(path.resolve(__dirname, CONFIG_FILE)))
+    data.append('file', fs.createReadStream(path.resolve(__dirname, CONFIG_FILE)))
+
     dataHeaders = data.getHeaders()
+    ADDITIONAL_HEADERS ? Object.assign(dataHeaders, JSON.parse(ADDITIONAL_HEADERS)) : ""
     break;
 
   case 'application/json':


### PR DESCRIPTION
This PR needs backwards compatibility checks for all the packages that use it to import configs. Currently the only one is dashboard-visualiser-jsreport. Merging this PR will mark the next minor release for this API, i.e., 1.1.0.